### PR TITLE
Access Control Prompt

### DIFF
--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11173.2" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11143.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,6 +23,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hWK-Bu-8u4">
+                                <rect key="frame" x="102" y="184" width="171" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <state key="normal" title="Delete from Keychain">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -29,6 +33,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b4T-JG-Zbo">
+                                <rect key="frame" x="120" y="131" width="134" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <state key="normal" title="Save in Keychain">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -38,21 +43,27 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NDv-PR-OK3">
+                                <rect key="frame" x="24" y="317" width="319" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Hello World!" borderStyle="roundedRect" placeholder="Text to save in KeychainSwift" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-Od-gCQ">
+                                <rect key="frame" x="16" y="54" width="343" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="w7p-LD-g9j"/>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="w7p-LD-g9j">
+                                <rect key="frame" x="243" y="225" width="51" height="31"/>
+                            </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Synchronizable" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pZ7-Ub-QmV">
+                                <rect key="frame" x="108" y="230" width="118" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QP7-SR-8QJ">
+                                <rect key="frame" x="114" y="264" width="147" height="33"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <state key="normal" title="Get from Keychain">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -61,24 +72,37 @@
                                     <action selector="onGetTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="OdD-Mn-cTm"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User Presence Required" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OkE-IS-UjV">
+                                <rect key="frame" x="50" y="97" width="185" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="f5y-33-IxW">
+                                <rect key="frame" x="243" y="92" width="51" height="31"/>
+                            </switch>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <gestureRecognizers/>
                         <constraints>
+                            <constraint firstItem="QP7-SR-8QJ" firstAttribute="top" secondItem="w7p-LD-g9j" secondAttribute="bottom" constant="8" symbolic="YES" id="04r-bK-2ew"/>
                             <constraint firstItem="QP7-SR-8QJ" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="2Qi-WJ-pvW"/>
-                            <constraint firstItem="w7p-LD-g9j" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" constant="50" id="5De-mx-U8l"/>
-                            <constraint firstItem="w7p-LD-g9j" firstAttribute="top" secondItem="hWK-Bu-8u4" secondAttribute="bottom" constant="20" id="BMz-4l-Y3k"/>
+                            <constraint firstItem="w7p-LD-g9j" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" constant="80" id="5De-mx-U8l"/>
+                            <constraint firstItem="w7p-LD-g9j" firstAttribute="top" secondItem="hWK-Bu-8u4" secondAttribute="bottom" constant="8" symbolic="YES" id="BMz-4l-Y3k"/>
                             <constraint firstItem="NDv-PR-OK3" firstAttribute="top" secondItem="QP7-SR-8QJ" secondAttribute="bottom" constant="20" id="HOc-KB-LXB"/>
+                            <constraint firstItem="b4T-JG-Zbo" firstAttribute="top" secondItem="f5y-33-IxW" secondAttribute="bottom" constant="8" symbolic="YES" id="HUP-2U-TPp"/>
                             <constraint firstItem="pZ7-Ub-QmV" firstAttribute="centerY" secondItem="w7p-LD-g9j" secondAttribute="centerY" id="Iau-2m-FSy"/>
+                            <constraint firstItem="f5y-33-IxW" firstAttribute="leading" secondItem="OkE-IS-UjV" secondAttribute="trailing" constant="8" symbolic="YES" id="RjS-cV-l6d"/>
                             <constraint firstAttribute="centerX" secondItem="hWK-Bu-8u4" secondAttribute="centerX" id="VJ4-XC-zFq"/>
+                            <constraint firstItem="f5y-33-IxW" firstAttribute="leading" secondItem="w7p-LD-g9j" secondAttribute="leading" id="ZsB-Nk-fsa"/>
                             <constraint firstAttribute="centerX" secondItem="b4T-JG-Zbo" secondAttribute="centerX" id="cbI-es-jn6"/>
                             <constraint firstItem="NDv-PR-OK3" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="8" id="f2v-aI-fuD"/>
-                            <constraint firstItem="QP7-SR-8QJ" firstAttribute="top" secondItem="w7p-LD-g9j" secondAttribute="bottom" constant="40" id="fPe-Dn-3wy"/>
-                            <constraint firstItem="b4T-JG-Zbo" firstAttribute="top" secondItem="xkp-Od-gCQ" secondAttribute="bottom" constant="24" id="hTO-Zq-9F4"/>
                             <constraint firstAttribute="trailingMargin" secondItem="xkp-Od-gCQ" secondAttribute="trailing" id="jW7-wf-Lg2"/>
+                            <constraint firstItem="f5y-33-IxW" firstAttribute="top" secondItem="xkp-Od-gCQ" secondAttribute="bottom" constant="8" symbolic="YES" id="kYK-9H-hDf"/>
                             <constraint firstItem="hWK-Bu-8u4" firstAttribute="top" secondItem="b4T-JG-Zbo" secondAttribute="bottom" constant="20" id="oVb-ZZ-R8a"/>
                             <constraint firstItem="w7p-LD-g9j" firstAttribute="leading" secondItem="pZ7-Ub-QmV" secondAttribute="trailing" constant="17" id="rR7-DW-fh2"/>
                             <constraint firstItem="xkp-Od-gCQ" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="sBp-QB-I3r"/>
+                            <constraint firstItem="f5y-33-IxW" firstAttribute="centerY" secondItem="OkE-IS-UjV" secondAttribute="centerY" id="uvq-97-TaP"/>
                             <constraint firstAttribute="trailingMargin" secondItem="NDv-PR-OK3" secondAttribute="trailing" constant="16" id="vAI-Yb-Kci"/>
                             <constraint firstItem="xkp-Od-gCQ" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="34" id="zhk-dr-xC7"/>
                         </constraints>
@@ -89,6 +113,7 @@
                     <connections>
                         <outlet property="synchronizableSwitch" destination="w7p-LD-g9j" id="xKt-Tv-MBN"/>
                         <outlet property="textField" destination="xkp-Od-gCQ" id="lld-hT-WbW"/>
+                        <outlet property="userPresenceSwitch" destination="f5y-33-IxW" id="FjC-Ip-COI"/>
                         <outlet property="valueLabel" destination="NDv-PR-OK3" id="O2G-6d-xCJ"/>
                     </connections>
                 </viewController>

--- a/Demo/ViewController.swift
+++ b/Demo/ViewController.swift
@@ -11,6 +11,8 @@ class ViewController: UIViewController {
   
   @IBOutlet weak var synchronizableSwitch: UISwitch!
   
+  @IBOutlet weak var userPresenceSwitch: UISwitch!
+  
   let keychain = KeychainSwift()
   
   override func viewDidLoad() {
@@ -24,8 +26,10 @@ class ViewController: UIViewController {
     
     if let text = textField.text {
       keychain.synchronizable = synchronizableSwitch.isOn
-      keychain.set(text, forKey: TegKeychainDemo_keyName)
-      updateValueLabel()
+      let saved = keychain.set(text,
+                               forKey: TegKeychainDemo_keyName,
+                               withControlFlags: userPresenceSwitch.isOn ? .userPresence : nil)
+      updateValueLabel(withSaved: saved ? text : "Failed to save")
     }
   }
   
@@ -43,10 +47,15 @@ class ViewController: UIViewController {
     updateValueLabel()
   }
   
-  private func updateValueLabel() {
+  private func updateValueLabel(withSaved saved: String? = nil) {
+    guard saved == nil else {
+      valueLabel.text = "Saved: " + saved!
+      return
+    }
+    
     keychain.synchronizable = synchronizableSwitch.isOn
     
-    if let value = keychain.get(TegKeychainDemo_keyName) {
+    if let value = keychain.get(TegKeychainDemo_keyName, prompt: "Please, authenticate") {
       valueLabel.text = "In Keychain: \(value)"
     } else {
       valueLabel.text = "no value in keychain"

--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -52,16 +52,18 @@ open class KeychainSwift {
   - parameter key: Key under which the text value is stored in the keychain.
   - parameter value: Text string to be written to the keychain.
   - parameter withAccess: Value that indicates when your app needs access to the text in the keychain item. By default the .AccessibleWhenUnlocked option is used that permits the data to be accessed only while the device is unlocked by the user.
-   
-   - returns: True if the text was successfully written to the keychain.
+  - parameter withControlFlags: SecAccessControlCreateFlags that identifies access control object constraint or policy.
+     
+  - returns: True if the text was successfully written to the keychain.
 
   */
   @discardableResult
   open func set(_ value: String, forKey key: String,
-                  withAccess access: KeychainSwiftAccessOptions? = nil) -> Bool {
+                withAccess access: KeychainSwiftAccessOptions? = nil,
+                withControlFlags flags: SecAccessControlCreateFlags? = nil) -> Bool {
     
     if let value = value.data(using: String.Encoding.utf8) {
-      return set(value, forKey: key, withAccess: access)
+      return set(value, forKey: key, withAccess: access, withControlFlags: flags)
     }
     
     return false
@@ -74,27 +76,28 @@ open class KeychainSwift {
   - parameter key: Key under which the data is stored in the keychain.
   - parameter value: Data to be written to the keychain.
   - parameter withAccess: Value that indicates when your app needs access to the text in the keychain item. By default the .AccessibleWhenUnlocked option is used that permits the data to be accessed only while the device is unlocked by the user.
-  
+  - parameter withControlFlags: SecAccessControlCreateFlags that identifies access control object constraint or policy.
+     
   - returns: True if the text was successfully written to the keychain.
   
   */
   @discardableResult
   open func set(_ value: Data, forKey key: String,
-    withAccess access: KeychainSwiftAccessOptions? = nil) -> Bool {
+                withAccess access: KeychainSwiftAccessOptions? = nil,
+                withControlFlags flags: SecAccessControlCreateFlags? = nil) -> Bool {
     
     delete(key) // Delete any existing key before saving it
 
-    let accessible = access?.value ?? KeychainSwiftAccessOptions.defaultOption.value
+    let accessible = access ?? KeychainSwiftAccessOptions.defaultOption
       
     let prefixedKey = keyWithPrefix(key)
       
     var query: [String : Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
-      KeychainSwiftConstants.valueData   : value,
-      KeychainSwiftConstants.accessible  : accessible
+      KeychainSwiftConstants.valueData   : value
     ]
-      
+    query = addAccessible(accessible, withControl: flags, to: query)
     query = addAccessGroupWhenPresent(query)
     query = addSynchronizableIfRequired(query, addingItems: true)
     lastQueryParameters = query
@@ -103,7 +106,7 @@ open class KeychainSwift {
     
     return lastResultCode == noErr
   }
-
+  
   /**
 
   Stores the boolean value in the keychain item under the given key.
@@ -111,18 +114,20 @@ open class KeychainSwift {
   - parameter key: Key under which the value is stored in the keychain.
   - parameter value: Boolean to be written to the keychain.
   - parameter withAccess: Value that indicates when your app needs access to the value in the keychain item. By default the .AccessibleWhenUnlocked option is used that permits the data to be accessed only while the device is unlocked by the user.
-
+  - parameter withControlFlags: SecAccessControlCreateFlags that identifies access control object constraint or policy.
+     
   - returns: True if the value was successfully written to the keychain.
 
   */
   @discardableResult
   open func set(_ value: Bool, forKey key: String,
-    withAccess access: KeychainSwiftAccessOptions? = nil) -> Bool {
+                withAccess access: KeychainSwiftAccessOptions? = nil,
+                withControlFlags flags: SecAccessControlCreateFlags? = nil) -> Bool {
   
     let bytes: [UInt8] = value ? [1] : [0]
     let data = Data(bytes: bytes)
 
-    return set(data, forKey: key, withAccess: access)
+    return set(data, forKey: key, withAccess: access, withControlFlags: flags)
   }
 
   /**
@@ -130,11 +135,13 @@ open class KeychainSwift {
   Retrieves the text value from the keychain that corresponds to the given key.
   
   - parameter key: The key that is used to read the keychain item.
+  - parameter prompt: String describing the operation for which the app is attempting to authenticate. When performing user authentication, the system includes the string in the user prompt. The app is responsible for text localization.
+  
   - returns: The text value from the keychain. Returns nil if unable to read the item.
   
   */
-  open func get(_ key: String) -> String? {
-    if let data = getData(key) {
+  open func get(_ key: String, prompt: String?=nil) -> String? {
+    if let data = getData(key, prompt: prompt) {
       
       if let currentString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String {
         return currentString
@@ -151,10 +158,12 @@ open class KeychainSwift {
   Retrieves the data from the keychain that corresponds to the given key.
   
   - parameter key: The key that is used to read the keychain item.
+  - parameter prompt: String describing the operation for which the app is attempting to authenticate. When performing user authentication, the system includes the string in the user prompt. The app is responsible for text localization.
+   
   - returns: The text value from the keychain. Returns nil if unable to read the item.
   
   */
-  open func getData(_ key: String) -> Data? {
+  open func getData(_ key: String, prompt: String?=nil) -> Data? {
     let prefixedKey = keyWithPrefix(key)
     
     var query: [String: Any] = [
@@ -163,7 +172,7 @@ open class KeychainSwift {
       KeychainSwiftConstants.returnData  : kCFBooleanTrue,
       KeychainSwiftConstants.matchLimit  : kSecMatchLimitOne
     ]
-    
+    query = addPromptIfProvided(query, prompt: prompt)
     query = addAccessGroupWhenPresent(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
     lastQueryParameters = query
@@ -184,11 +193,13 @@ open class KeychainSwift {
   Retrieves the boolean value from the keychain that corresponds to the given key.
 
   - parameter key: The key that is used to read the keychain item.
+  - parameter prompt: String describing the operation for which the app is attempting to authenticate. When performing user authentication, the system includes the string in the user prompt. The app is responsible for text localization.
+   
   - returns: The boolean value from the keychain. Returns nil if unable to read the item.
 
   */
-  open func getBool(_ key: String) -> Bool? {
-    guard let data = getData(key) else { return nil }
+  open func getBool(_ key: String, prompt: String?=nil) -> Bool? {
+    guard let data = getData(key, prompt: prompt) else { return nil }
     guard let firstBit = data.first else { return nil }
     return firstBit == 1
   }
@@ -265,6 +276,51 @@ open class KeychainSwift {
     if !synchronizable { return items }
     var result: [String: Any] = items
     result[KeychainSwiftConstants.attrSynchronizable] = addingItems == true ? true : kSecAttrSynchronizableAny
+    return result
+  }
+  
+  /**
+ 
+  Adds `kSecAttrAccessControl` if flags are provided or kSecAttrAccessible if not.
+   
+   - parameter flags: `SecAccessControlCreateFlags` stands for access control flags. If not provided, `access control` item will not be included into dictionary, but `accessible` item will be.
+   - parameter items: The dictionary where the `kSecAttrAccessControl` or `kSecAttrAccessible` items will be added.
+   
+   - returns: the dictionary with `kSecAttrAccessControl` or `kSecAttrAccessible` item depending on wheather flags were profided.
+   
+  */
+  func addAccessible(_ accessible: KeychainSwiftAccessOptions,
+                             withControl flags: SecAccessControlCreateFlags?,
+                             to items: [String : Any]) -> [String : Any] {
+    var result: [String: Any] = items
+    
+    if let flags = flags, let accessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                                              accessible.rawValue,
+                                                                              flags,
+                                                                              nil) {
+      result[KeychainSwiftConstants.accessControl] = accessControl
+    } else {
+      result[KeychainSwiftConstants.accessible] = accessible.value
+    }
+    
+    return result
+  }
+  
+  /**
+   
+   Adds `kSecUseOperationPrompt` if provided.
+   
+   - parameter prompt: String describing the operation for which the app is attempting to authenticate. When performing user authentication, the system includes the string in the user prompt. The app is responsible for text localization.
+   - parameter items: The dictionary where the `kSecAttrAccessControl` or `kSecAttrAccessible` items will be added.
+   
+   - returns: the dictionary with `kSecUseOperationPrompt` if provided. Otherwise, it returns the original dictionary.
+   
+   */
+  func addPromptIfProvided(_ items: [String : Any], prompt: String?) -> [String : Any] {
+    guard let prompt = prompt else { return items }
+    
+    var result: [String: Any] = items
+    result[KeychainSwiftConstants.prompt] = prompt
     return result
   }
 }

--- a/Sources/KeychainSwiftAccessOptions.swift
+++ b/Sources/KeychainSwiftAccessOptions.swift
@@ -77,27 +77,31 @@ public enum KeychainSwiftAccessOptions {
   }
   
   var value: String {
+    return toString(self.rawValue)
+  }
+  
+  var rawValue : CFString {
     switch self {
     case .accessibleWhenUnlocked:
-      return toString(kSecAttrAccessibleWhenUnlocked)
+      return kSecAttrAccessibleWhenUnlocked
       
     case .accessibleWhenUnlockedThisDeviceOnly:
-      return toString(kSecAttrAccessibleWhenUnlockedThisDeviceOnly)
+      return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
       
     case .accessibleAfterFirstUnlock:
-      return toString(kSecAttrAccessibleAfterFirstUnlock)
+      return kSecAttrAccessibleAfterFirstUnlock
       
     case .accessibleAfterFirstUnlockThisDeviceOnly:
-      return toString(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+      return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
       
     case .accessibleAlways:
-      return toString(kSecAttrAccessibleAlways)
+      return kSecAttrAccessibleAlways
       
     case .accessibleWhenPasscodeSetThisDeviceOnly:
-      return toString(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
+      return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
       
     case .accessibleAlwaysThisDeviceOnly:
-      return toString(kSecAttrAccessibleAlwaysThisDeviceOnly)
+      return kSecAttrAccessibleAlwaysThisDeviceOnly
     }
   }
   

--- a/Sources/TegKeychainConstants.swift
+++ b/Sources/TegKeychainConstants.swift
@@ -13,6 +13,9 @@ public struct KeychainSwiftConstants {
    */
   public static var accessible: String { return toString(kSecAttrAccessible) }
   
+  /// Used for specifing access control policy or constraint
+  public static var accessControl: String { return toString(kSecAttrAccessControl) }
+  
   /// Used for specifying a String key when setting/getting a Keychain value.
   public static var attrAccount: String { return toString(kSecAttrAccount) }
 
@@ -30,6 +33,9 @@ public struct KeychainSwiftConstants {
   
   /// Used for specifying a value when setting a Keychain value.
   public static var valueData: String { return toString(kSecValueData) }
+  
+  /// Used for specifying a string describing the operation for which the app is attempting to authenticate.
+  public static var prompt: String { return toString(kSecUseOperationPrompt) }
   
   static func toString(_ value: CFString) -> String {
     return value as String

--- a/Tests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests.swift
@@ -103,4 +103,19 @@ class KeychainSwiftTests: XCTestCase {
     
     XCTAssertEqual("hello two", obj.get("key 2")!)
   }
+  
+  // MARK: - Set with accessControl
+  // -----------------------
+  func testSet_accessControl() {
+    XCTAssertTrue(obj.set("hello kitty", forKey: "another key", withControlFlags: .userPresence))
+  }
+  
+  // MARK: - Get with accessControl
+  // -----------------------
+  
+  func testGet_accessControl() {
+    XCTAssertTrue(obj.set("hello kitty", forKey: "another key", withAccess: .accessibleWhenUnlocked, withControlFlags: .userPresence))
+    XCTAssertEqual("hello kitty", obj.get("another key"))
+    XCTAssertEqual("hello kitty", obj.get("another key", prompt: "desperately need it"))
+  }
 }


### PR DESCRIPTION
This branch allows to save items in Keychain with access control flag (ex. `.userPresence`) and later prompt user with a special string (ex. either via TouchID or passcode) before item will be received from Keychain. Rather useful for storing passwords in Keychain and biometric authentication.
![touchid-ui](https://cloud.githubusercontent.com/assets/12777516/21030437/1d1174a6-bda7-11e6-964b-cbe64e020c03.png)

Added:
1) set-methods: optional parameter access control flag. I'm pretty sure this flag of type `SecAccessControlCreateFlags` does not need any swifty wrappers.
2) get-methods: optional parameter prompt which is string written in system authentication UI
3) supporting private methods and enum cases
4) unit tests
5) ios demo: switcher User Presence Required