### PR TITLE
Added `isInKeychain`

### DIFF
--- a/KeychainSwift.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/KeychainSwift.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -26,8 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7ED6C9761B1C118F00FE8090"
+               BuildableName = "KeychainSwiftTests.xctest"
+               BlueprintName = "KeychainSwiftTests"
+               ReferencedContainer = "container:KeychainSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -45,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -267,4 +267,16 @@ open class KeychainSwift {
     result[KeychainSwiftConstants.attrSynchronizable] = addingItems == true ? true : kSecAttrSynchronizableAny
     return result
   }
+	
+  /**
+	
+  Returns the the presence of the provided key in the keychain.
+	
+  - parameter key: The key to be searched in the keychain.
+  - returns: True if value was found in the Keychain
+	
+  */
+  open func isInKeychain(key: String) -> Bool {
+	return getData(key) != nil
+  }
 }

--- a/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
@@ -103,4 +103,13 @@ class KeychainSwiftTests: XCTestCase {
     
     XCTAssertEqual("hello two", obj.get("key 2")!)
   }
+	
+  //MARK: - Presence
+  // --------------------
+  func testPresence() {
+	obj.clear()
+	obj.set("hello", forKey: "key 1")
+	XCTAssert(obj.isInKeychain(key: "key 1") == true)
+	XCTAssert(obj.isInKeychain(key: "key 2") == false)
+  }
 }


### PR DESCRIPTION
Added a new method called `isInKeychain(key: String)` which verifies whether the provided `key` is present in the keychain or not.

Some simple use cases for this could be, to execute a certain action if the key is present/absent or to prompt the user before overwriting the existing key.