### PR TITLE
`KeychainSwiftAccessOptions` tweak for Objective-C

### DIFF
--- a/Sources/KeychainSwiftAccessOptions.swift
+++ b/Sources/KeychainSwiftAccessOptions.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Security
 
 /**
@@ -5,7 +6,8 @@ import Security
 These options are used to determine when a keychain item should be readable. The default value is AccessibleWhenUnlocked.
 
 */
-public enum KeychainSwiftAccessOptions {
+@objc
+public enum KeychainSwiftAccessOptions: Int {
   
   /**
   


### PR DESCRIPTION
Marked up `KeychainSwiftAccessOptions` with a `@objc` annotation and made an integer raw type so this enum can be used when bridging in Objective-C.