### PR TITLE
Enable "swift test" command

### DIFF
--- a/KeychainSwift.xcodeproj/project.pbxproj
+++ b/KeychainSwift.xcodeproj/project.pbxproj
@@ -27,9 +27,6 @@
 		508566A81FA34EB1004208ED /* macOS_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508566991FA34EB1004208ED /* macOS_Tests.swift */; };
 		508566A91FA34EB1004208ED /* SynchronizableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5085669A1FA34EB1004208ED /* SynchronizableTests.swift */; };
 		508566AA1FA34EB1004208ED /* SynchronizableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5085669A1FA34EB1004208ED /* SynchronizableTests.swift */; };
-		7E3A6B681D3F62CC007C5B1F /* KeychainSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED6C98D1B1C128100FE8090 /* KeychainSwift.swift */; };
-		7E3A6B691D3F62CC007C5B1F /* KeychainSwiftAccessOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED6C98E1B1C128100FE8090 /* KeychainSwiftAccessOptions.swift */; };
-		7E3A6B6A1D3F62CC007C5B1F /* TegKeychainConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED6C98F1B1C128100FE8090 /* TegKeychainConstants.swift */; };
 		7E3A6B7E1D3F6779007C5B1F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3A6B7D1D3F6779007C5B1F /* AppDelegate.swift */; };
 		7E3A6B801D3F6779007C5B1F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3A6B7F1D3F6779007C5B1F /* ViewController.swift */; };
 		7E3A6B821D3F6779007C5B1F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E3A6B811D3F6779007C5B1F /* Assets.xcassets */; };
@@ -83,6 +80,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7ED6C96B1B1C118F00FE8090;
 			remoteInfo = KeychainSwift;
+		};
+		BF4250102343FE8400F7B44C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7ED6C9631B1C118F00FE8090 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 232B4C791BC29950001F2B7A;
+			remoteInfo = "KeychainSwift-macOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -474,6 +478,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				BF4250112343FE8400F7B44C /* PBXTargetDependency */,
 			);
 			name = "macOS Tests";
 			productName = "macOS Tests";
@@ -738,11 +743,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				508566AA1FA34EB1004208ED /* SynchronizableTests.swift in Sources */,
-				7E3A6B691D3F62CC007C5B1F /* KeychainSwiftAccessOptions.swift in Sources */,
 				508566A41FA34EB1004208ED /* KeychainSwiftTests.swift in Sources */,
-				7E3A6B6A1D3F62CC007C5B1F /* TegKeychainConstants.swift in Sources */,
 				508566A21FA34EB1004208ED /* KeychainSwiftPrefixedTests.swift in Sources */,
-				7E3A6B681D3F62CC007C5B1F /* KeychainSwift.swift in Sources */,
 				508566A81FA34EB1004208ED /* macOS_Tests.swift in Sources */,
 				5085669C1FA34EB1004208ED /* AccessGroupTests.swift in Sources */,
 			);
@@ -816,6 +818,11 @@
 			isa = PBXTargetDependency;
 			target = 7ED6C96B1B1C118F00FE8090 /* KeychainSwift */;
 			targetProxy = 7ED6C9C11B1C13AA00FE8090 /* PBXContainerItemProxy */;
+		};
+		BF4250112343FE8400F7B44C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 232B4C791BC29950001F2B7A /* KeychainSwift-macOS */;
+			targetProxy = BF4250102343FE8400F7B44C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/KeychainSwift.xcodeproj/xcshareddata/xcschemes/KeychainSwift-macOS.xcscheme
+++ b/KeychainSwift.xcodeproj/xcshareddata/xcschemes/KeychainSwift-macOS.xcscheme
@@ -28,9 +28,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7E3A6B5F1D3F62C2007C5B1F"
+               BuildableName = "macOS Tests.xctest"
+               BlueprintName = "macOS Tests"
+               ReferencedContainer = "container:KeychainSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +59,6 @@
             ReferencedContainer = "container:KeychainSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Package.swift
+++ b/Package.swift
@@ -10,5 +10,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "KeychainSwift", dependencies: [], path: "Sources"),
+        .testTarget(name: "KeychainSwiftTests", dependencies: ["KeychainSwift"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,10 @@ let package = Package(
     ],
     targets: [
         .target(name: "KeychainSwift", dependencies: [], path: "Sources"),
-        .testTarget(name: "KeychainSwiftTests", dependencies: ["KeychainSwift"])
+        .testTarget(
+            name: "KeychainSwiftTests", 
+            dependencies: ["KeychainSwift"],
+            exclude: ["ClearTests.swift"]
+        )
     ]
 )

--- a/Tests/KeychainSwiftTests/AccessGroupTests.swift
+++ b/Tests/KeychainSwiftTests/AccessGroupTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import KeychainSwift
 
 class AccessGroupTests: XCTestCase {
   

--- a/Tests/KeychainSwiftTests/ClearTests.swift
+++ b/Tests/KeychainSwiftTests/ClearTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import KeychainSwift
 
 class ClearTests: XCTestCase {
   

--- a/Tests/KeychainSwiftTests/ConcurrencyTests.swift
+++ b/Tests/KeychainSwiftTests/ConcurrencyTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+@testable import KeychainSwift
 
 class ConcurrencyTests: XCTestCase {
 

--- a/Tests/KeychainSwiftTests/KeychainSwiftPrefixedTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftPrefixedTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import KeychainSwift
 
 class KeychainWithPrefixTests: XCTestCase {
   

--- a/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import KeychainSwift
 
 class KeychainSwiftTests: XCTestCase {
   

--- a/Tests/KeychainSwiftTests/SynchronizableTests.swift
+++ b/Tests/KeychainSwiftTests/SynchronizableTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import KeychainSwift
 
 class SynchronizableTests: XCTestCase {
   

--- a/Tests/KeychainSwiftTests/macOS Tests/macOS_Tests.swift
+++ b/Tests/KeychainSwiftTests/macOS Tests/macOS_Tests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import KeychainSwift
 
 class macOS_Tests: XCTestCase {
         


### PR DESCRIPTION
Fixes https://github.com/evgenyneu/keychain-swift/issues/112

When I forked this project, I ran into the issue linked above when running `swift test` on my Mac. This PR fixes the tests by adding a test target to Package.swift, and adding import statements to all of the test files.

One thing to note is that `testClear()` fails with error code ` -25244` (errSecInvalidOwnerEdit). I believe this is due to the fact that `clear()` is attempting to delete everything stored in the Mac keychain (which would obviously be a bad thing). Fortunately, keychain permissions prevent this from happening with the aforementioned error. Not sure how to get that test to pass.