### PR TITLE
Removed non-recommended accessibility levels

### DIFF
--- a/Sources/KeychainSwiftAccessOptions.swift
+++ b/Sources/KeychainSwiftAccessOptions.swift
@@ -44,16 +44,7 @@ public enum KeychainSwiftAccessOptions {
   
   */
   case accessibleAfterFirstUnlockThisDeviceOnly
-  
-  /**
-  
-  The data in the keychain item can always be accessed regardless of whether the device is locked.
-  
-  This is not recommended for application use. Items with this attribute migrate to a new device when using encrypted backups.
-  
-  */
-  case accessibleAlways
-  
+
   /**
   
   The data in the keychain can only be accessed when the device is unlocked. Only available if a passcode is set on the device.
@@ -62,15 +53,6 @@ public enum KeychainSwiftAccessOptions {
   
   */
   case accessibleWhenPasscodeSetThisDeviceOnly
-  
-  /**
-  
-  The data in the keychain item can always be accessed regardless of whether the device is locked.
-  
-  This is not recommended for application use. Items with this attribute do not migrate to a new device. Thus, after restoring from a backup of a different device, these items will not be present.
-  
-  */
-  case accessibleAlwaysThisDeviceOnly
   
   static var defaultOption: KeychainSwiftAccessOptions {
     return .accessibleWhenUnlocked
@@ -90,14 +72,8 @@ public enum KeychainSwiftAccessOptions {
     case .accessibleAfterFirstUnlockThisDeviceOnly:
       return toString(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
       
-    case .accessibleAlways:
-      return toString(kSecAttrAccessibleAlways)
-      
     case .accessibleWhenPasscodeSetThisDeviceOnly:
       return toString(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
-      
-    case .accessibleAlwaysThisDeviceOnly:
-      return toString(kSecAttrAccessibleAlwaysThisDeviceOnly)
     }
   }
   


### PR DESCRIPTION
These accessibility levels are deprecated as of macOS 10.14.

This way we can build without warnings in Xcode 11.