### PR TITLE
Added Access options to the get parameters with a default option set.

### DIFF
--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -169,16 +169,17 @@ open class KeychainSwift {
     lock.lock()
     defer { lock.unlock() }
     
-    let accessible = access?.value ?? KeychainSwiftAccessOptions.defaultOption.value
-    
     let prefixedKey = keyWithPrefix(key)
     
     var query: [String: Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
       KeychainSwiftConstants.matchLimit  : kSecMatchLimitOne,
-      KeychainSwiftConstants.accessible  : accessible
     ]
+    
+    if let access = access {
+      query[KeychainSwiftConstants.accessible] = access.value
+    }
     
     if asReference {
       query[KeychainSwiftConstants.returnReference] = kCFBooleanTrue

--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -141,8 +141,8 @@ open class KeychainSwift {
   - returns: The text value from the keychain. Returns nil if unable to read the item.
   
   */
-  open func get(_ key: String) -> String? {
-    if let data = getData(key) {
+  open func get(_ key: String, withAccess access: KeychainSwiftAccessOptions? = nil) -> String? {
+    if let data = getData(key, withAccess: access) {
       
       if let currentString = String(data: data, encoding: .utf8) {
         return currentString
@@ -163,18 +163,21 @@ open class KeychainSwift {
   - returns: The text value from the keychain. Returns nil if unable to read the item.
   
   */
-  open func getData(_ key: String, asReference: Bool = false) -> Data? {
+  open func getData(_ key: String, asReference: Bool = false, withAccess access: KeychainSwiftAccessOptions? = nil) -> Data? {
     // The lock prevents the code to be run simlultaneously
     // from multiple threads which may result in crashing
     lock.lock()
     defer { lock.unlock() }
+    
+    let accessible = access?.value ?? KeychainSwiftAccessOptions.defaultOption.value
     
     let prefixedKey = keyWithPrefix(key)
     
     var query: [String: Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
-      KeychainSwiftConstants.matchLimit  : kSecMatchLimitOne
+      KeychainSwiftConstants.matchLimit  : kSecMatchLimitOne,
+      KeychainSwiftConstants.accessible  : accessible
     ]
     
     if asReference {
@@ -208,8 +211,8 @@ open class KeychainSwift {
   - returns: The boolean value from the keychain. Returns nil if unable to read the item.
 
   */
-  open func getBool(_ key: String) -> Bool? {
-    guard let data = getData(key) else { return nil }
+  open func getBool(_ key: String, withAccess access: KeychainSwiftAccessOptions? = nil) -> Bool? {
+    guard let data = getData(key, withAccess: access) else { return nil }
     guard let firstBit = data.first else { return nil }
     return firstBit == 1
   }

--- a/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
@@ -78,6 +78,20 @@ class KeychainSwiftTests: XCTestCase {
   func testGet_returnNilWhenValueNotSet() {
     XCTAssert(obj.get("key 1") == nil)
   }
+    
+  func testGet_usesAccessibleWhenUnlockedByDefault() {
+    obj.set("hello :)", forKey: "key 1")
+    XCTAssertTrue(obj.get("key 1") != nil)
+    let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
+    XCTAssertEqual(KeychainSwiftAccessOptions.accessibleWhenUnlocked.value, accessValue!)
+  }
+    
+  func testGet_withAccessOption() {
+    obj.set("hello :)", forKey: "key 1", withAccess: .accessibleAfterFirstUnlock)
+    XCTAssertTrue(obj.get("key 1", withAccess: .accessibleAfterFirstUnlock) != nil)
+    let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
+    XCTAssertEqual(KeychainSwiftAccessOptions.accessibleAfterFirstUnlock.value, accessValue!)
+  }
 
   // MARK: - Get bool
   // -----------------------

--- a/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
@@ -83,7 +83,7 @@ class KeychainSwiftTests: XCTestCase {
     obj.set("hello :)", forKey: "key 1")
     XCTAssertTrue(obj.get("key 1") != nil)
     let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
-    XCTAssertEqual(KeychainSwiftAccessOptions.accessibleWhenUnlocked.value, accessValue!)
+    XCTAssert(accessValue == nil)
   }
     
   func testGet_withAccessOption() {


### PR DESCRIPTION
Added Access options to the get parameters with a default option set. As posted in:

https://github.com/evgenyneu/keychain-swift/issues/78#issuecomment-549045569

This provides a way for the developer to specify the same accessibility level that they saved the keychain item as to query out the keychain item. By default it is set to when unlocked, but it can be default to be afterFirst unlock to be able to access in the background

Also Added some basic tests to validate the passing of the access options for the get parameter.
