### PR TITLE
Swift-tools-version bump to 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This fixes minimum deployment target version error when project generated in Xcode 12