### PR TITLE
Added macos support

### DIFF
--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -16,6 +16,11 @@ open class KeychainSwift {
   var keyPrefix = "" // Can be useful in test.
   
   /**
+   A key whose value is a string indicating the item's service.
+   */
+  open var serviceName: String?
+  
+  /**
 
   Specify an access group that will be used to access keychain items. Access groups can be used to share keychain items between applications. When access group value is nil all application access groups are being accessed. Access group name is used by all functions: set, get, delete and clear.
 
@@ -102,7 +107,8 @@ open class KeychainSwift {
       KeychainSwiftConstants.valueData   : value,
       KeychainSwiftConstants.accessible  : accessible
     ]
-      
+    
+    query = addServiceWhenPresent(query)
     query = addAccessGroupWhenPresent(query)
     query = addSynchronizableIfRequired(query, addingItems: true)
     lastQueryParameters = query
@@ -324,6 +330,14 @@ open class KeychainSwift {
     
     var result: [String: Any] = items
     result[KeychainSwiftConstants.accessGroup] = accessGroup
+    return result
+  }
+  
+  func addServiceWhenPresent(_ items: [String: Any]) -> [String: Any] {
+    guard let serviceName = serviceName else { return items }
+    
+    var result: [String: Any] = items
+    result[KeychainSwiftConstants.service] = serviceName
     return result
   }
   

--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -38,6 +38,17 @@ open class KeychainSwift {
   */
   open var synchronizable: Bool = false
 
+  /**
+   
+   A key whose value indicates whether to treat macOS keychain items like iOS keychain items.
+   
+   The data protection key affects operations only in macOS. Other platforms automatically behave as if the key is set to true, and ignore the key in the query dictionary. You can safely use the key on all platforms.
+   
+   It’s highly recommended that you set the value of this key to true for all keychain operations. This key helps to improve the portability of your code across platforms. Use it unless you specifically need access to items previously stored in a legacy keychain in macOS.
+   
+   */
+  open var isUseDataProtection: Bool = true
+  
   private let lock = NSLock()
 
   
@@ -110,6 +121,7 @@ open class KeychainSwift {
     
     query = addServiceWhenPresent(query)
     query = addAccessGroupWhenPresent(query)
+    query = addUseDataProtectionIfRequired(query)
     query = addSynchronizableIfRequired(query, addingItems: true)
     lastQueryParameters = query
     
@@ -190,6 +202,7 @@ open class KeychainSwift {
     }
     
     query = addAccessGroupWhenPresent(query)
+    query = addUseDataProtectionIfRequired(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
     lastQueryParameters = query
     
@@ -254,6 +267,7 @@ open class KeychainSwift {
     ]
   
     query = addAccessGroupWhenPresent(query)
+    query = addUseDataProtectionIfRequired(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
 
     var result: AnyObject?
@@ -288,6 +302,7 @@ open class KeychainSwift {
     ]
     
     query = addAccessGroupWhenPresent(query)
+    query = addUseDataProtectionIfRequired(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
     lastQueryParameters = query
     
@@ -312,6 +327,7 @@ open class KeychainSwift {
     
     var query: [String: Any] = [ kSecClass as String : kSecClassGenericPassword ]
     query = addAccessGroupWhenPresent(query)
+    query = addUseDataProtectionIfRequired(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
     lastQueryParameters = query
     
@@ -339,6 +355,16 @@ open class KeychainSwift {
     var result: [String: Any] = items
     result[KeychainSwiftConstants.service] = serviceName
     return result
+  }
+  
+  func addUseDataProtectionIfRequired(_ items: [String: Any]) -> [String: Any] {
+    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
+      var result: [String: Any] = items
+      result[KeychainSwiftConstants.useDataProtection] = isUseDataProtection ? kCFBooleanTrue : kCFBooleanFalse
+      return result
+    } else {
+      return items
+    }
   }
   
   /**

--- a/Sources/TegKeychainConstants.swift
+++ b/Sources/TegKeychainConstants.swift
@@ -8,7 +8,11 @@ public struct KeychainSwiftConstants {
   
   /// A key whose value is a string indicating the item's service.
   public static var service: String { return toString(kSecAttrService) }
-
+  
+  /// A key whose value indicates whether to treat macOS keychain items like iOS keychain items.
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+  public static var useDataProtection: String { return toString(kSecUseDataProtectionKeychain) }
+  
   /**
    
    A value that indicates when your app needs access to the data in a keychain item. The default value is AccessibleWhenUnlocked. For a list of possible values, see KeychainSwiftAccessOptions.

--- a/Sources/TegKeychainConstants.swift
+++ b/Sources/TegKeychainConstants.swift
@@ -6,6 +6,9 @@ public struct KeychainSwiftConstants {
   /// Specifies a Keychain access group. Used for sharing Keychain items between apps.
   public static var accessGroup: String { return toString(kSecAttrAccessGroup) }
   
+  /// A key whose value is a string indicating the item's service.
+  public static var service: String { return toString(kSecAttrService) }
+
   /**
    
    A value that indicates when your app needs access to the data in a keychain item. The default value is AccessibleWhenUnlocked. For a list of possible values, see KeychainSwiftAccessOptions.


### PR DESCRIPTION
Hi @evgenyneu!
thank you for `keychain-swift`. It saves my time!

But I want to share with you some behavior for macOS.

### There was a problem:

I am using keychain in my macOS app to store jwt tokens (access and refresh)(`kSecClassGenericPassword`) and I have figured out that I can't manage existed data via the same app with another name. I have built two equal applications with different app names:

for example **App1.app** and **App2.app** 
Note: it's the same build, but with only a different - app file name.

And if I create the keychain item using the first app (**App1.app**) I can't remove it from the second one.

If I double click on the keychain item in Keychain Access default App I can see that there is only one app in Access Control tab (with the name **App1.app**). 

### The Solution

Finally, I have found the solution in this article: [Making macOS Keychain behave as iOS keychain](https://medium.com/@bhojwaniravi/making-mac-oskeychain-behave-as-ios-keychain-60eedb37c173)

And have made a pull request based on this article.



