### PR TITLE
Refactor thread safety of KeychainSwift class

### DIFF
--- a/Distrib/KeychainSwiftDistrib.swift
+++ b/Distrib/KeychainSwiftDistrib.swift
@@ -48,7 +48,7 @@ open class KeychainSwift {
   */
   open var synchronizable: Bool = false
 
-  private let lock = NSLock()
+  private let recursiveLock = NSRecursiveLock()
 
   
   /// Instantiate a KeychainSwift object
@@ -102,10 +102,10 @@ open class KeychainSwift {
     
     // The lock prevents the code to be run simultaneously
     // from multiple threads which may result in crashing
-    lock.lock()
-    defer { lock.unlock() }
+    recursiveLock.lock()
+    defer { recursiveLock.unlock() }
     
-    deleteNoLock(key) // Delete any existing key before saving it
+    delete(key) // Delete any existing key before saving it
 
     let accessible = access?.value ?? KeychainSwiftAccessOptions.defaultOption.value
       
@@ -181,8 +181,8 @@ open class KeychainSwift {
   open func getData(_ key: String, asReference: Bool = false) -> Data? {
     // The lock prevents the code to be run simultaneously
     // from multiple threads which may result in crashing
-    lock.lock()
-    defer { lock.unlock() }
+    recursiveLock.lock()
+    defer { recursiveLock.unlock() }
     
     let prefixedKey = keyWithPrefix(key)
     
@@ -241,10 +241,23 @@ open class KeychainSwift {
   open func delete(_ key: String) -> Bool {
     // The lock prevents the code to be run simultaneously
     // from multiple threads which may result in crashing
-    lock.lock()
-    defer { lock.unlock() }
+    recursiveLock.lock()
+    defer { recursiveLock.unlock() }
     
-    return deleteNoLock(key)
+    let prefixedKey = keyWithPrefix(key)
+    
+    var query: [String: Any] = [
+      KeychainSwiftConstants.klass       : kSecClassGenericPassword,
+      KeychainSwiftConstants.attrAccount : prefixedKey
+    ]
+    
+    query = addAccessGroupWhenPresent(query)
+    query = addSynchronizableIfRequired(query, addingItems: false)
+    lastQueryParameters = query
+    
+    lastResultCode = SecItemDelete(query as CFDictionary)
+    
+    return lastResultCode == noErr
   }
   
   /**
@@ -280,32 +293,6 @@ open class KeychainSwift {
   }
     
   /**
-   
-  Same as `delete` but is only accessed internally, since it is not thread safe.
-   
-   - parameter key: The key that is used to delete the keychain item.
-   - returns: True if the item was successfully deleted.
-   
-   */
-  @discardableResult
-  func deleteNoLock(_ key: String) -> Bool {
-    let prefixedKey = keyWithPrefix(key)
-    
-    var query: [String: Any] = [
-      KeychainSwiftConstants.klass       : kSecClassGenericPassword,
-      KeychainSwiftConstants.attrAccount : prefixedKey
-    ]
-    
-    query = addAccessGroupWhenPresent(query)
-    query = addSynchronizableIfRequired(query, addingItems: false)
-    lastQueryParameters = query
-    
-    lastResultCode = SecItemDelete(query as CFDictionary)
-    
-    return lastResultCode == noErr
-  }
-
-  /**
   
   Deletes all Keychain items used by the app. Note that this method deletes all items regardless of the prefix settings used for initializing the class.
   
@@ -316,8 +303,8 @@ open class KeychainSwift {
   open func clear() -> Bool {
     // The lock prevents the code to be run simultaneously
     // from multiple threads which may result in crashing
-    lock.lock()
-    defer { lock.unlock() }
+    recursiveLock.lock()
+    defer { recursiveLock.unlock() }
     
     var query: [String: Any] = [ kSecClass as String : kSecClassGenericPassword ]
     query = addAccessGroupWhenPresent(query)


### PR DESCRIPTION
Switched `NSLock` to `NSRecursiveLock` to avoid the need for an internal `deleteNoLock()` method and remove it.

`NSRecursiveLock` is conform to the same `NSLocking` protocol as `NSLock` but the fundamental difference is that `NSRecursiveLock` allows locking resources recursively.  The main rule here is `.unlock()` calls must be as much as `.lock()` calls.
That is why we no more need the internal `deleteNoLock` method, which was added, as I suppose, to avoid `deadlock`.

- KeychainSwiftDistrib.swift file - updated
- All tests passed

<img width="301" alt="Screenshot 2022-05-11 at 16 17 00" src="https://user-images.githubusercontent.com/43936569/167864594-22656234-0d0a-40d4-84f0-3a9bbba0deb2.png">
