### PR TITLE
Bumped swift tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version: 5.7.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7.1
+// swift-tools-version: 5.7.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
There's an error about missing swift tools version when importing using the latest Xcode (14.1). Bumping the swift tools version to the latest one solved the issue