### PR TITLE
Remove unnecessary space because SPM can't read it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7.0
+// swift-tools-version:5.7.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Remove unnecessary space, because SPM can't read it when fetching the package. Gives error suggesting to add swift tools version, because simply doesn't recognize yours which has a space

<img width="1064" alt="Screen Shot 2023-01-18 at 10 27 26 AM" src="https://user-images.githubusercontent.com/43179082/213109822-cd2af302-fb1b-44cf-acef-ff1e6f4e5fb4.png">
