### PR TITLE
Add privacy manifest to Podspec

### DIFF
--- a/KeychainSwift.podspec
+++ b/KeychainSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "KeychainSwift"
-  s.version     = "21.0.0"
+  s.version     = "22.0.0"
   s.license     = { :type => "MIT" }
   s.homepage    = "https://github.com/evgenyneu/keychain-swift"
   s.summary     = "A library for saving text and data in the Keychain with Swift."
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.source      = { :git => "https://github.com/evgenyneu/keychain-swift.git", :tag => s.version }
   s.screenshots  = "https://raw.githubusercontent.com/evgenyneu/keychain-swift/master/graphics/keychain-swift-demo-3.png"
   s.source_files = "Sources/*.swift"
+  s.resource = 'Sources/PrivacyInfo.xcprivacy'
   s.ios.deployment_target = "12.0"
   s.osx.deployment_target = "10.13"
   s.watchos.deployment_target = "4.0"


### PR DESCRIPTION
Privacy manifest `PrivacyInfo.xcprivacy` has not been added to the pod spec. In result `KeychainSwift.framework' was missing the manifest file.

This PR adds manifest to the framework
<img width="487" alt="Screenshot 2024-04-03 at 15 06 46" src="https://github.com/evgenyneu/keychain-swift/assets/76966254/8bd4fccb-4875-4ea4-a192-572bdb8173e3">
