### PR TITLE
Update PrivacyInfo.xcprivacy

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -5,7 +5,16 @@
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
Since the app doesn't track or use users' information, I added this default privacy manifest file to prevent Apple warnings