### PR TITLE
Add full conformance to Sendable + thread safety

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7.1
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
@@ -20,5 +20,6 @@ let package = Package(
             dependencies: ["KeychainSwift"],
             exclude: ["ClearTests.swift"]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v6]
 )

--- a/Sources/KeychainError.swift
+++ b/Sources/KeychainError.swift
@@ -1,0 +1,28 @@
+//
+//  KeychainError.swift
+//  KeychainSwift
+//
+//  Created by Lennard Sprong on 20/02/2025.
+//
+
+import Foundation
+import Security
+
+public struct KeychainError : CustomNSError {
+    public init(_ code: OSStatus) {
+        errorCode = code
+    }
+    
+    public static var errorDomain: String { NSOSStatusErrorDomain }
+    
+    /// The result code for the operation.
+    public let errorCode: OSStatus
+    
+    /// Retrieve the localized description for this error. This uses ``/Security/SecCopyErrorMessageString(_:_:)`` internally.
+    public var localizedDescription: String {
+        if let message = SecCopyErrorMessageString(errorCode, nil) {
+            return message as String
+        }
+        return "KeychainError \(errorCode)"
+    }
+}

--- a/Sources/KeychainError.swift
+++ b/Sources/KeychainError.swift
@@ -8,21 +8,35 @@
 import Foundation
 import Security
 
-public struct KeychainError : CustomNSError {
-    public init(_ code: OSStatus) {
-        errorCode = code
+public struct KeychainError : RawRepresentable, CustomStringConvertible {
+    public init(rawValue: OSStatus) {
+        self.rawValue = rawValue
     }
     
-    public static var errorDomain: String { NSOSStatusErrorDomain }
+    public init(_ code: OSStatus) {
+        rawValue = code
+    }
     
     /// The result code for the operation.
-    public let errorCode: OSStatus
+    public let rawValue: OSStatus
     
     /// Retrieve the localized description for this error. This uses ``/Security/SecCopyErrorMessageString(_:_:)`` internally.
     public var localizedDescription: String {
-        if let message = SecCopyErrorMessageString(errorCode, nil) {
+        if let message = SecCopyErrorMessageString(rawValue, nil) {
             return message as String
         }
-        return "KeychainError \(errorCode)"
+        return description
     }
+    
+    public var description: String {
+        "KeychainError(\(rawValue))"
+    }
+}
+
+extension KeychainError : CustomNSError {
+    public static var errorDomain: String { NSOSStatusErrorDomain }
+}
+
+extension KeychainError : LocalizedError {
+    public var errorDescription: String? { localizedDescription }
 }

--- a/Sources/KeychainSwift.swift
+++ b/Sources/KeychainSwift.swift
@@ -6,7 +6,7 @@ import Foundation
 A collection of helper functions for saving text and data in the keychain.
 
 */
-open class KeychainSwift {
+open class KeychainSwift: @unchecked Sendable {
   
   var lastQueryParameters: [String: Any]? // Used by the unit tests
 
@@ -17,8 +17,8 @@ open class KeychainSwift {
   Specify an access group that will be used to access keychain items. Access groups can be used to share keychain items between applications. When access group value is nil all application access groups are being accessed. Access group name is used by all functions: set, get, delete and clear.
 
   */
-  open var accessGroup: String?
-  
+  open var accessGroup: String? { _accessGroup }
+  private let _accessGroup: String?
   
   /**
    
@@ -28,21 +28,24 @@ open class KeychainSwift {
   Does not work on macOS.
    
   */
-  open var synchronizable: Bool = false
+  open var synchronizable: Bool { _synchronizable }
+  private let _synchronizable: Bool
 
   private let lock = NSLock()
 
-  
-  /// Instantiate a KeychainSwift object
-  public init() { }
-  
   /**
   
+   Instantiate a KeychainSwift object
+   
   - parameter keyPrefix: a prefix that is added before the key in get/set methods. Note that `clear` method still clears everything from the Keychain.
+  - parameter accessGroup: Access groups can be used to share keychain items between applications. When access group value is nil all application access groups are being accessed. Access group name is used by all functions: set, get, delete and clear.
+  - parameter synchronizable: Specifies whether the items can be synchronized with other devices through iCloud. Setting this property to true will add the item to other devices with the `set` method and obtain synchronizable items with the `get` command. Deleting synchronizable items will remove them from all devices. In order for keychain synchronization to work the user must enable "Keychain" in iCloud settings. Does not work on macOS.
 
   */
-  public init(keyPrefix: String) {
+  public init(keyPrefix: String = "", accessGroup: String? = nil, synchronizable: Bool = false) {
     self.keyPrefix = keyPrefix
+    _accessGroup = accessGroup
+    _synchronizable = synchronizable
   }
   
   /**

--- a/Sources/KeychainSwiftAccessOptions.swift
+++ b/Sources/KeychainSwiftAccessOptions.swift
@@ -5,7 +5,7 @@ import Security
 These options are used to determine when a keychain item should be readable. The default value is AccessibleWhenUnlocked.
 
 */
-public enum KeychainSwiftAccessOptions {
+public enum KeychainSwiftAccessOptions: Sendable {
   
   /**
   

--- a/Tests/KeychainSwiftTests/AccessGroupTests.swift
+++ b/Tests/KeychainSwiftTests/AccessGroupTests.swift
@@ -9,7 +9,7 @@ class AccessGroupTests: XCTestCase {
     super.setUp()
     
     obj = KeychainSwift()
-    obj.clear()
+    try? obj.clear()
     obj.lastQueryParameters = nil
     obj.accessGroup = nil
   }
@@ -42,25 +42,25 @@ class AccessGroupTests: XCTestCase {
   
   func testSet() {
     obj.accessGroup = "123.my.test.group"
-    obj.set("hello :)", forKey: "key 1")
+    try? obj.set("hello :)", forKey: "key 1")
     XCTAssertEqual("123.my.test.group", obj.lastQueryParameters?["agrp"] as! String)
   }
   
   func testGet() {
     obj.accessGroup = "123.my.test.group"
-    _ = obj.get("key 1")
+    _ = try? obj.get("key 1")
     XCTAssertEqual("123.my.test.group", obj.lastQueryParameters?["agrp"] as! String)
   }
   
   func testDelete() {
     obj.accessGroup = "123.my.test.group"
-    obj.delete("key 1")
+    _ = try? obj.delete("key 1")
     XCTAssertEqual("123.my.test.group", obj.lastQueryParameters?["agrp"] as! String)
   }
   
   func testClear() {
     obj.accessGroup = "123.my.test.group"
-    obj.clear()
+    try? obj.clear()
     XCTAssertEqual("123.my.test.group", obj.lastQueryParameters?["agrp"] as! String)
   }
 }

--- a/Tests/KeychainSwiftTests/AccessGroupTests.swift
+++ b/Tests/KeychainSwiftTests/AccessGroupTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 class AccessGroupTests: XCTestCase {
   
-  var obj: KeychainSwift!
+  var obj: TestableKeychainSwift!
   
   override func setUp() {
     super.setUp()
     
-    obj = KeychainSwift()
+    obj = TestableKeychainSwift()
     try? obj.clear()
     obj.lastQueryParameters = nil
     obj.accessGroup = nil

--- a/Tests/KeychainSwiftTests/AccessGroupTests.swift
+++ b/Tests/KeychainSwiftTests/AccessGroupTests.swift
@@ -17,12 +17,12 @@ class AccessGroupTests: XCTestCase {
   // MARK: - Add access group
   
   func testAddAccessGroup() {
-    let items: [String: Any] = [
+    var result: [String: Any] = [
       "one": "two"
     ]
     
     obj.accessGroup = "123.my.test.group"
-    let result = obj.addAccessGroupWhenPresent(items)
+    obj.addAccessGroupWhenPresent(&result)
     
     XCTAssertEqual(2, result.count)
     XCTAssertEqual("two", result["one"] as! String)
@@ -30,11 +30,11 @@ class AccessGroupTests: XCTestCase {
   }
   
   func testAddAccessGroup_nil() {
-    let items: [String: Any] = [
+    var result: [String: Any] = [
       "one": "two"
     ]
     
-    let result = obj.addAccessGroupWhenPresent(items)
+    obj.addAccessGroupWhenPresent(&result)
     
     XCTAssertEqual(1, result.count)
     XCTAssertEqual("two", result["one"] as! String)

--- a/Tests/KeychainSwiftTests/AllKeysTests.swift
+++ b/Tests/KeychainSwiftTests/AllKeysTests.swift
@@ -12,12 +12,12 @@ import XCTest
 
 class AllKeysTests: XCTestCase {
   
-  var obj: KeychainSwift!
+  var obj: TestableKeychainSwift!
   
   override func setUp() {
     super.setUp()
     
-    obj = KeychainSwift()
+    obj = TestableKeychainSwift()
     try? obj.clear()
   }
   

--- a/Tests/KeychainSwiftTests/AllKeysTests.swift
+++ b/Tests/KeychainSwiftTests/AllKeysTests.swift
@@ -18,7 +18,7 @@ class AllKeysTests: XCTestCase {
     super.setUp()
     
     obj = KeychainSwift()
-    obj.clear()
+    try? obj.clear()
   }
   
   // MARK: - allKeys
@@ -28,12 +28,12 @@ class AllKeysTests: XCTestCase {
     ]
     
     items.enumerated().forEach { enumerator in
-        self.obj!.set("\(enumerator.offset)", forKey: enumerator.element)
+      try? self.obj!.set("\(enumerator.offset)", forKey: enumerator.element)
     }
     
     XCTAssertEqual(["one", "two"], obj.allKeys)
     
-    obj.clear()
+    try? obj.clear()
     XCTAssertEqual(obj.allKeys, [])
     
   }

--- a/Tests/KeychainSwiftTests/ClearTests.swift
+++ b/Tests/KeychainSwiftTests/ClearTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 class ClearTests: XCTestCase {
   
-  var obj: KeychainSwift!
+  var obj: TestableKeychainSwift!
   
   override func setUp() {
     super.setUp()
     
-    obj = KeychainSwift()
+    obj = TestableKeychainSwift()
   }
   
   func testClear() {

--- a/Tests/KeychainSwiftTests/KeychainSwiftPrefixedTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftPrefixedTests.swift
@@ -3,15 +3,15 @@ import XCTest
 
 class KeychainWithPrefixTests: XCTestCase {
   
-  var prefixed: KeychainSwift!
-  var nonPrefixed: KeychainSwift!
+  var prefixed: TestableKeychainSwift!
+  var nonPrefixed: TestableKeychainSwift!
 
   
   override func setUp() {
     super.setUp()
     
-    prefixed = KeychainSwift(keyPrefix: "test_prefix_")
-    nonPrefixed = KeychainSwift()
+    prefixed = TestableKeychainSwift(keyPrefix: "test_prefix_")
+    nonPrefixed = TestableKeychainSwift()
     
     try? prefixed.clear()
     try? nonPrefixed.clear()

--- a/Tests/KeychainSwiftTests/KeychainSwiftPrefixedTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftPrefixedTests.swift
@@ -13,13 +13,13 @@ class KeychainWithPrefixTests: XCTestCase {
     prefixed = KeychainSwift(keyPrefix: "test_prefix_")
     nonPrefixed = KeychainSwift()
     
-    prefixed.clear()
-    nonPrefixed.clear()
+    try? prefixed.clear()
+    try? nonPrefixed.clear()
     
     prefixed.lastQueryParameters = nil
   }
   
-  func testKeyWithPrefix() {
+  func testKeyWithPrefix() throws {
     XCTAssertEqual("test_prefix_key", prefixed.keyWithPrefix("key"))
     XCTAssertEqual("key", nonPrefixed.keyWithPrefix("key"))
   }
@@ -27,34 +27,34 @@ class KeychainWithPrefixTests: XCTestCase {
   // MARK: - Set text
   // -----------------------
   
-  func testSet() {
+  func testSet() throws {
     let key = "key 1"
-    XCTAssertTrue(prefixed.set("prefixed", forKey: key))
-    XCTAssertTrue(nonPrefixed.set("non prefixed", forKey: key))
+    try prefixed.set("prefixed", forKey: key)
+    try nonPrefixed.set("non prefixed", forKey: key)
     
-    XCTAssertEqual("prefixed", prefixed.get(key)!)
-    XCTAssertEqual("non prefixed", nonPrefixed.get(key)!)
+    XCTAssertEqual("prefixed", try prefixed.get(key)!)
+    XCTAssertEqual("non prefixed", try nonPrefixed.get(key)!)
   }
   
   
   // MARK: - Set data
   // -----------------------
   
-  func testSetData() {
+  func testSetData() throws {
     let key = "key 123"
     
     let dataPrefixed = "prefixed".data(using: String.Encoding.utf8)!
     let dataNonPrefixed = "non prefixed".data(using: String.Encoding.utf8)!
     
-    XCTAssertTrue(prefixed.set(dataPrefixed, forKey: key))
-    XCTAssertTrue(nonPrefixed.set(dataNonPrefixed, forKey: key))
+    try prefixed.set(dataPrefixed, forKey: key)
+    try nonPrefixed.set(dataNonPrefixed, forKey: key)
 
     
-    let dataFromKeychainPrefixed = prefixed.getData(key)!
+    let dataFromKeychainPrefixed = try prefixed.getData(key)!
     let textFromKeychainPrefixed = String(data: dataFromKeychainPrefixed, encoding: .utf8)!
     XCTAssertEqual("prefixed", textFromKeychainPrefixed)
     
-    let dataFromKeychainNonPrefixed = nonPrefixed.getData(key)!
+    let dataFromKeychainNonPrefixed = try nonPrefixed.getData(key)!
     let textFromKeychainNonPrefixed = String(data: dataFromKeychainNonPrefixed, encoding: .utf8)!
     XCTAssertEqual("non prefixed", textFromKeychainNonPrefixed)
   }
@@ -62,15 +62,15 @@ class KeychainWithPrefixTests: XCTestCase {
   // MARK: - Delete
   // -----------------------
   
-  func testDelete() {
+  func testDelete() throws {
     let key = "key 1"
-    XCTAssertTrue(prefixed.set("prefixed", forKey: key))
-    XCTAssertTrue(nonPrefixed.set("non prefixed", forKey: key))
+    try prefixed.set("prefixed", forKey: key)
+    try nonPrefixed.set("non prefixed", forKey: key)
     
-    prefixed.delete(key)
+    try prefixed.delete(key)
     
-    XCTAssert(prefixed.get(key) == nil)
-    XCTAssertFalse(nonPrefixed.get(key) == nil) // non-prefixed still exists
+    XCTAssert(try prefixed.get(key) == nil)
+    XCTAssertFalse(try nonPrefixed.get(key) == nil) // non-prefixed still exists
   }
   
 }

--- a/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 class KeychainSwiftTests: XCTestCase {
   
-  var obj: KeychainSwift!
+  var obj: TestableKeychainSwift!
   
   override func setUp() {
     super.setUp()
     
-    obj = KeychainSwift()
+    obj = TestableKeychainSwift()
     try? obj.clear()
     obj.lastQueryParameters = nil
   }

--- a/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
+++ b/Tests/KeychainSwiftTests/KeychainSwiftTests.swift
@@ -9,27 +9,27 @@ class KeychainSwiftTests: XCTestCase {
     super.setUp()
     
     obj = KeychainSwift()
-    obj.clear()
+    try? obj.clear()
     obj.lastQueryParameters = nil
   }
 
   // MARK: - Set text
   // -----------------------
 
-  func testSet() {
-    XCTAssertTrue(obj.set("hello :)", forKey: "key 1"))
-    XCTAssertEqual("hello :)", obj.get("key 1")!)
+  func testSet() throws {
+    try obj.set("hello :)", forKey: "key 1")
+    XCTAssertEqual("hello :)", try obj.get("key 1")!)
   }
   
-  func testSet_usesAccessibleWhenUnlockedByDefault() {
-    XCTAssertTrue(obj.set("hello :)", forKey: "key 1"))
+  func testSet_usesAccessibleWhenUnlockedByDefault() throws {
+    try obj.set("hello :)", forKey: "key 1")
     
     let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
     XCTAssertEqual(KeychainSwiftAccessOptions.accessibleWhenUnlocked.value, accessValue!)
   }
   
-  func testSetWithAccessOption() {
-    obj.set("hello :)", forKey: "key 1", withAccess: .accessibleAfterFirstUnlock)
+  func testSetWithAccessOption() throws {
+    try obj.set("hello :)", forKey: "key 1", withAccess: .accessibleAfterFirstUnlock)
     let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
     XCTAssertEqual(KeychainSwiftAccessOptions.accessibleAfterFirstUnlock.value, accessValue!)
   }
@@ -37,20 +37,20 @@ class KeychainSwiftTests: XCTestCase {
   // MARK: - Set data
   // -----------------------
   
-  func testSetData() {
+  func testSetData() throws {
     let data = "hello world".data(using: String.Encoding.utf8)!
     
-    XCTAssertTrue(obj.set(data, forKey: "key 123"))
+    try obj.set(data, forKey: "key 123")
     
-    let dataFromKeychain = obj.getData("key 123")!
+    let dataFromKeychain = try obj.getData("key 123")!
     let textFromKeychain = String(data: dataFromKeychain, encoding:String.Encoding.utf8)!
     XCTAssertEqual("hello world", textFromKeychain)
   }
   
-  func testSetData_usesAccessibleWhenUnlockedByDefault() {
+  func testSetData_usesAccessibleWhenUnlockedByDefault() throws {
     let data = "hello world".data(using: String.Encoding.utf8)!
     
-    obj.set(data, forKey: "key 123")
+    try obj.set(data, forKey: "key 123")
     
     let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
     XCTAssertEqual(KeychainSwiftAccessOptions.accessibleWhenUnlocked.value, accessValue!)
@@ -59,15 +59,15 @@ class KeychainSwiftTests: XCTestCase {
   // MARK: - Set bool
   // -----------------------
 
-  func testSetBool() {
-    XCTAssertTrue(obj.set(true, forKey: "key bool"))
-    XCTAssertTrue(obj.getBool("key bool")!)
-    XCTAssertTrue(obj.set(false, forKey: "key bool"))
-    XCTAssertFalse(obj.getBool("key bool")!)
+  func testSetBool() throws {
+    try obj.set(true, forKey: "key bool")
+    XCTAssertTrue(try obj.getBool("key bool")!)
+    try obj.set(false, forKey: "key bool")
+    XCTAssertFalse(try obj.getBool("key bool")!)
   }
 
-  func testSetBool_usesAccessibleWhenUnlockedByDefault() {
-    XCTAssertTrue(obj.set(false, forKey: "key bool"))
+  func testSetBool_usesAccessibleWhenUnlockedByDefault() throws {
+    try obj.set(false, forKey: "key bool")
     let accessValue = obj.lastQueryParameters?[KeychainSwiftConstants.accessible] as? String
     XCTAssertEqual(KeychainSwiftAccessOptions.accessibleWhenUnlocked.value, accessValue!)
   }
@@ -75,33 +75,33 @@ class KeychainSwiftTests: XCTestCase {
   // MARK: - Get
   // -----------------------
 
-  func testGet_returnNilWhenValueNotSet() {
-    XCTAssert(obj.get("key 1") == nil)
+  func testGet_returnNilWhenValueNotSet() throws {
+    XCTAssert(try obj.get("key 1") == nil)
   }
 
   // MARK: - Get bool
   // -----------------------
 
-  func testGetBool_returnNilWhenValueNotSet() {
-    XCTAssert(obj.getBool("some bool key") == nil)
+  func testGetBool_returnNilWhenValueNotSet() throws {
+    XCTAssert(try obj.getBool("some bool key") == nil)
   }
 
   // MARK: - Delete
   // -----------------------
 
-  func testDelete() {
-    obj.set("hello :)", forKey: "key 1")
-    obj.delete("key 1")
+  func testDelete() throws {
+    try obj.set("hello :)", forKey: "key 1")
+    try obj.delete("key 1")
     
-    XCTAssert(obj.get("key 1") == nil)
+    XCTAssert(try obj.get("key 1") == nil)
   }
 
-  func testDelete_deleteOnSingleKey() {
-    obj.set("hello :)", forKey: "key 1")
-    obj.set("hello two", forKey: "key 2")
+  func testDelete_deleteOnSingleKey() throws {
+    try obj.set("hello :)", forKey: "key 1")
+    try obj.set("hello two", forKey: "key 2")
 
-    obj.delete("key 1")
+    try obj.delete("key 1")
     
-    XCTAssertEqual("hello two", obj.get("key 2")!)
+    XCTAssertEqual("hello two", try obj.get("key 2")!)
   }
 }

--- a/Tests/KeychainSwiftTests/SynchronizableTests.swift
+++ b/Tests/KeychainSwiftTests/SynchronizableTests.swift
@@ -9,7 +9,7 @@ class SynchronizableTests: XCTestCase {
     super.setUp()
     
     obj = KeychainSwift()
-    obj.clear()
+    try? obj.clear()
     obj.lastQueryParameters = nil
     obj.synchronizable = false
   }
@@ -57,12 +57,12 @@ class SynchronizableTests: XCTestCase {
   
   func testSet() {
     obj.synchronizable = true
-    obj.set("hello :)", forKey: "key 1")
+    try? obj.set("hello :)", forKey: "key 1")
     XCTAssertEqual(true, obj.lastQueryParameters?["sync"] as! Bool)
   }
   
   func testSet_doNotSetSynchronizable() {
-    obj.set("hello :)", forKey: "key 1")
+    try? obj.set("hello :)", forKey: "key 1")
     XCTAssertNil(obj.lastQueryParameters?["sync"])
   }
   
@@ -70,12 +70,12 @@ class SynchronizableTests: XCTestCase {
   
   func testGet() {
     obj.synchronizable = true
-    _ = obj.get("key 1")
+    _ = try? obj.get("key 1")
     XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as! String)
   }
   
   func testGet_doNotSetSynchronizable() {
-    _ = obj.get("key 1")
+    _ = try? obj.get("key 1")
     XCTAssertNil(obj.lastQueryParameters?["sync"])
   }
   
@@ -83,12 +83,12 @@ class SynchronizableTests: XCTestCase {
 
   func testDelete() {
     obj.synchronizable = true
-    obj.delete("key 1")
+    _ = try? obj.delete("key 1")
     XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as! String)
   }
   
   func testDelete_doNotSetSynchronizable() {
-    obj.delete("key 1")
+    _ = try? obj.delete("key 1")
     XCTAssertNil(obj.lastQueryParameters?["sync"])
   }
   
@@ -96,12 +96,12 @@ class SynchronizableTests: XCTestCase {
   
   func testClear() {
     obj.synchronizable = true
-    obj.clear()
+    try? obj.clear()
     XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as! String)
   }
   
   func testClear_doNotSetSynchronizable() {
-    obj.clear()
+    try? obj.clear()
     XCTAssertNil(obj.lastQueryParameters?["sync"])
   }
 }

--- a/Tests/KeychainSwiftTests/SynchronizableTests.swift
+++ b/Tests/KeychainSwiftTests/SynchronizableTests.swift
@@ -17,12 +17,12 @@ class SynchronizableTests: XCTestCase {
   // MARK: - addSynchronizableIfRequired
   
   func testAddSynchronizableGroup_addItemsFalse() {
-    let items: [String: Any] = [
+    var result: [String: Any] = [
       "one": "two"
     ]
     
     obj.synchronizable = true
-    let result = obj.addSynchronizableIfRequired(items, addingItems: false)
+    obj.addSynchronizableIfRequired(&result, addingItems: false)
     
     XCTAssertEqual(2, result.count)
     XCTAssertEqual("two", result["one"] as? String)
@@ -30,12 +30,12 @@ class SynchronizableTests: XCTestCase {
   }
   
   func testAddSynchronizableGroup_addItemsTrue() {
-    let items: [String: Any] = [
+      var result: [String: Any] = [
       "one": "two"
     ]
     
     obj.synchronizable = true
-    let result = obj.addSynchronizableIfRequired(items, addingItems: true)
+    obj.addSynchronizableIfRequired(&result, addingItems: true)
     
     XCTAssertEqual(2, result.count)
     XCTAssertEqual("two", result["one"] as? String)
@@ -43,11 +43,11 @@ class SynchronizableTests: XCTestCase {
   }
   
   func testAddSynchronizableGroup_nil() {
-    let items: [String: Any] = [
+    var result: [String: Any] = [
       "one": "two"
     ]
     
-    let result = obj.addSynchronizableIfRequired(items, addingItems: false)
+    obj.addSynchronizableIfRequired(&result, addingItems: false)
     
     XCTAssertEqual(1, result.count)
     XCTAssertEqual("two", result["one"] as? String)

--- a/Tests/KeychainSwiftTests/SynchronizableTests.swift
+++ b/Tests/KeychainSwiftTests/SynchronizableTests.swift
@@ -3,12 +3,12 @@ import XCTest
 
 class SynchronizableTests: XCTestCase {
   
-  var obj: KeychainSwift!
+  var obj: TestableKeychainSwift!
   
   override func setUp() {
     super.setUp()
     
-    obj = KeychainSwift()
+    obj = TestableKeychainSwift()
     try? obj.clear()
     obj.lastQueryParameters = nil
     obj.synchronizable = false
@@ -25,8 +25,8 @@ class SynchronizableTests: XCTestCase {
     let result = obj.addSynchronizableIfRequired(items, addingItems: false)
     
     XCTAssertEqual(2, result.count)
-    XCTAssertEqual("two", result["one"] as! String)
-    XCTAssertEqual(kSecAttrSynchronizableAny as String, result["sync"] as! String)
+    XCTAssertEqual("two", result["one"] as? String)
+    XCTAssertEqual(kSecAttrSynchronizableAny as String, result["sync"] as? String)
   }
   
   func testAddSynchronizableGroup_addItemsTrue() {
@@ -38,8 +38,8 @@ class SynchronizableTests: XCTestCase {
     let result = obj.addSynchronizableIfRequired(items, addingItems: true)
     
     XCTAssertEqual(2, result.count)
-    XCTAssertEqual("two", result["one"] as! String)
-    XCTAssertEqual(true, result["sync"] as! Bool)
+    XCTAssertEqual("two", result["one"] as? String)
+    XCTAssertEqual(true, result["sync"] as? Bool)
   }
   
   func testAddSynchronizableGroup_nil() {
@@ -50,7 +50,7 @@ class SynchronizableTests: XCTestCase {
     let result = obj.addSynchronizableIfRequired(items, addingItems: false)
     
     XCTAssertEqual(1, result.count)
-    XCTAssertEqual("two", result["one"] as! String)
+    XCTAssertEqual("two", result["one"] as? String)
   }
   
   // MARK: - Set
@@ -58,7 +58,7 @@ class SynchronizableTests: XCTestCase {
   func testSet() {
     obj.synchronizable = true
     try? obj.set("hello :)", forKey: "key 1")
-    XCTAssertEqual(true, obj.lastQueryParameters?["sync"] as! Bool)
+    XCTAssertEqual(true, obj.lastQueryParameters?["sync"] as? Bool)
   }
   
   func testSet_doNotSetSynchronizable() {
@@ -71,7 +71,7 @@ class SynchronizableTests: XCTestCase {
   func testGet() {
     obj.synchronizable = true
     _ = try? obj.get("key 1")
-    XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as! String)
+    XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as? String)
   }
   
   func testGet_doNotSetSynchronizable() {
@@ -84,7 +84,7 @@ class SynchronizableTests: XCTestCase {
   func testDelete() {
     obj.synchronizable = true
     _ = try? obj.delete("key 1")
-    XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as! String)
+    XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as? String)
   }
   
   func testDelete_doNotSetSynchronizable() {
@@ -97,7 +97,7 @@ class SynchronizableTests: XCTestCase {
   func testClear() {
     obj.synchronizable = true
     try? obj.clear()
-    XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as! String)
+    XCTAssertEqual(kSecAttrSynchronizableAny as String, obj.lastQueryParameters?["sync"] as? String)
   }
   
   func testClear_doNotSetSynchronizable() {

--- a/Tests/KeychainSwiftTests/TestableKeychainSwift.swift
+++ b/Tests/KeychainSwiftTests/TestableKeychainSwift.swift
@@ -1,0 +1,26 @@
+//
+//  TestableKeychainSwift.swift
+//  KeychainSwift
+//
+//  Created by Lennard Sprong on 21/02/2025.
+//
+
+@testable import KeychainSwift
+
+class TestableKeychainSwift : KeychainSwift, @unchecked Sendable {
+    var _accessGroup: String? = nil
+    override var accessGroup: String? {
+        get { _accessGroup }
+        set { _accessGroup = newValue }
+    }
+    
+    var _synchronizable: Bool = false
+    override var synchronizable: Bool {
+        get { _synchronizable }
+        set { _synchronizable = newValue }
+    }
+    
+    init(keyPrefix: String = "") {
+        super.init(keyPrefix: keyPrefix)
+    }
+}


### PR DESCRIPTION
Fixes #186.

Contains several breaking changes, including a full refactor of the result code model to use Swift errors instead, and the removal of several public setters.

I've been using this fork for several months in my projects with no issues, on iOS 13 and above.